### PR TITLE
adding a generic github actions workflow to build, tag and push a dockerimage to dockerhub

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -3,8 +3,6 @@ name: Docker Image CI
 on:
   push:
     branches: [ master ]
-  pull_request:
-    branches: [ master ]
 
 jobs:
 

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,18 @@
+name: Docker Image CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build the Docker image
+      run: docker build . --file Dockerfile --tag my-image-name:$(date +%s)

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,8 +1,10 @@
 name: Docker Image CI
 
 on:
-  push:
-    branches: [ master ]
+  workflow_dispatch:
+    inputs:
+      tags:
+        description: 'Docker Tag override: [leave empty if not needed]'
 
 jobs:
 
@@ -15,13 +17,16 @@ jobs:
     - run: git fetch --prune --unshallow --tags
     - name: Get current version
       id: version
-      run: echo "::set-output name=version::$(git describe --tags --abbrev=0)"
+      run: echo "REPO_VERSION=$(git describe --tags --abbrev=0)" >> $GITHUB_ENV
+    - name: Docker image tag override
+      if: ${{ github.event.inputs.tags && github.event.inputs.tags != '' }}
+      run: echo "REPO_VERSION=${{github.event.inputs.tags}}" >> $GITHUB_ENV
     - name: docker login
       env:
         DOCKER_USER: ${{secrets.DOCKER_USER}}
         DOCKER_PASSWORD: ${{secrets.DOCKER_PASSWORD}}
       run: docker login -u $DOCKER_USER -p $DOCKER_PASSWORD
     - name: Build the Docker image
-      run: docker build . --file build/docker/Dockerfile --tag infectieradarbe/logging-service-image:${{ steps.version.outputs.version }}
+      run: docker build . --file build/docker/Dockerfile --tag ${{secrets.DOCKER_ORGANIZATION}}/${{secrets.DOCKER_REPO_NAME}}:$REPO_VERSION
     - name: Push Docker image
-      run: docker push infectieradarbe/logging-service-image:${{ steps.version.outputs.version }}
+      run: docker push ${{secrets.DOCKER_ORGANIZATION}}/${{secrets.DOCKER_REPO_NAME}}:$REPO_VERSION

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -14,5 +14,15 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+    - name: Get current date
+      id: date
+      run: echo "::set-output name=date::$(date +'%Y-%m-%d-%H.%M')"
+    - name: docker login
+      env:
+        DOCKER_USER: ${{secrets.DOCKER_USER}}
+        DOCKER_PASSWORD: ${{secrets.DOCKER_PASSWORD}}
+      run: docker login -u $DOCKER_USER -p $DOCKER_PASSWORD
     - name: Build the Docker image
-      run: docker build . --file Dockerfile --tag my-image-name:$(date +%s)
+      run: docker build . --file build/docker/Dockerfile --tag infectieradarbe/logging-service-image:${{ steps.date.outputs.date }}
+    - name: Push Docker image
+      run: docker push infectieradarbe/logging-service-image:${{ steps.date.outputs.date }}

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -12,15 +12,16 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Get current date
-      id: date
-      run: echo "::set-output name=date::$(date +'%Y-%m-%d-%H.%M')"
+    - run: git fetch --prune --unshallow --tags
+    - name: Get current version
+      id: version
+      run: echo "::set-output name=version::$(git describe --tags --abbrev=0)"
     - name: docker login
       env:
         DOCKER_USER: ${{secrets.DOCKER_USER}}
         DOCKER_PASSWORD: ${{secrets.DOCKER_PASSWORD}}
       run: docker login -u $DOCKER_USER -p $DOCKER_PASSWORD
     - name: Build the Docker image
-      run: docker build . --file build/docker/Dockerfile --tag infectieradarbe/logging-service-image:${{ steps.date.outputs.date }}
+      run: docker build . --file build/docker/Dockerfile --tag infectieradarbe/logging-service-image:${{ steps.version.outputs.version }}
     - name: Push Docker image
-      run: docker push infectieradarbe/logging-service-image:${{ steps.date.outputs.date }}
+      run: docker push infectieradarbe/logging-service-image:${{ steps.version.outputs.version }}

--- a/README.md
+++ b/README.md
@@ -1,0 +1,56 @@
+# Logging Service
+This backend service of the Influenzanet is responsible to record actions in the system as logs in the mongo database.
+
+
+
+
+## Test
+With a running go setup, you can use the command
+```
+make test
+```
+to execute the test script. Makefile expects the test script to be at test/test.sh. The test script could contain DB secrets therefore are not added to this git repository. An example [test script](test/example_test_srcipt.sh) can be found in the `test` folder.
+
+Currently the tests also require a working database connection to a mongoDB instance.
+
+## Build
+### Docker
+Dockerfile(s) are located in `build/docker`. The default Dockerfile is using a multistage build and create a minimal image base on `scratch`.
+To trigger the build process using the default docker file call:
+```
+make docker
+```
+This will use the most recent git tag to tag the docker image.
+
+#### Contribute:
+Feel free to create your own Dockerfile (e.g. compiling and deploying to specific target images), eventually others may need the same.
+You can create a pull request with adding the Dockerfile into `build/docker` with a good name that it can be identified well, and add a short description to `build/docker/readme.md` about the purpose and speciality of it.
+
+An example to run your created docker image - with the set environment variables - can be found [here](build/docker/example).
+
+## Develop
+### API
+API definition and data models for the gRPC service can be found in the `api` folder.
+To compile the definitions, use:
+```
+make api
+```
+This generates the go package into `pgk/api`.
+
+
+
+## Github Actions
+
+The repository also contains a Github actions script to build and push a docker image to a dockerhub repository. 
+The action is a manually triggered workflow dispatch that requires the following secrets to be configured in order to run successfully:
+
+| Secret Name        | Value to be configured           |
+| -------------- | -------------------- |
+| DOCKER_USER     | Username of the account authorized to push docker image to the dockerhub repository |
+| DOCKER_PASSWORD     | Password of the account authorized to push docker image to the dockerhub repository |
+| DOCKER_ORGANIZATION     | Organization or collection name that hosts the repository being pushed to |
+| DOCKER_REPO_NAME     | Name of the logging service dockerhub image repository |
+
+Once this is configured, navigate to the Actions tab on Github > Docker Image CI > Run Workflow
+
+By default the version to be tagged is picked from the latest release version, but it can also be overriden by a user specified tag name.


### PR DESCRIPTION
Features added:

- Builds only by manually triggered workflow dispatch
- Version picked according to latest created release
- Version can also be overridden through user input during manual trigger
- Docker credentials, Dockerhub destination organisation and repository names configurable through Github Secrets
- Readme section to help configure and run GitHub actions

This PR addresses the problem of having to re-configure image build pipelines for each of the new platforms, i.e. Italy, Denmark etc.